### PR TITLE
Adding NIH CSL for mendeley

### DIFF
--- a/mendeley/fogies-nih.csl
+++ b/mendeley/fogies-nih.csl
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Fogies NIH Format</title>
+    <id>https://homes.cs.washington.edu/~jfogarty/mendeley/fogies-nih</id>
+    <link href="https://homes.cs.washington.edu/~jfogarty/mendeley/fogies-nih.csl" rel="self"/>
+    <author>
+      <name>Ravi Karkar</name>
+      <email>ravikarkar@gmail.com</email>
+    </author>
+    <contributor>
+      <name>James Fogarty</name>
+    </contributor>
+    <contributor>
+      <name>Eric Baumer</name>
+    </contributor>
+    <contributor>
+      <name>Lilly Irani</name>
+    </contributor>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <contributor>
+      <name>Yevgeniy Medynskiy</name>
+    </contributor>
+    <contributor>
+      <name>Svetlana Yarosh</name>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+    <updated>2018-02-28T06:25:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <group suffix=".">
+      <names variable="author">
+        <name delimiter=", " and="text" sort-separator=", "/>
+        <label form="short" prefix=" (" suffix=")"/>
+        <substitute>
+          <names variable="editor"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name delimiter=", " and="text" delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="journal">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="container-title" font-style="italic"/>
+      </group>
+	  <group>
+	    <group font-style="italic">
+		  <text variable="volume"/>
+	    </group>
+        <text variable="issue" prefix="(" suffix=")"/>
+	  </group>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="conference">
+    <group delimiter=", ">
+      <text variable="container-title" font-style="italic"/>
+    </group>
+  </macro>
+  <macro name="book-publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="http://doi.org/"/>
+      </if>
+      <else variable="URL">
+        <text variable="URL"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pmcid">
+    <choose>
+      <if variable="PMCID">
+        <text variable="PMCID" prefix="PMCID: "/>
+      </if>
+      <else variable="PMID"> 
+        <text variable="PMID" prefix="PMID: "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="sortkey">
+    <group delimiter=" ">
+	  <choose>
+	    <if macro="author">
+		  <text macro="author"/>
+		</if>
+		<else>
+		  <text variable="title"/>
+		</else>
+	  </choose>
+      <text macro="year"/>
+	  <text variable="title"/>
+    </group>
+  </macro>
+  <citation>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <group delimiter=":">
+        <text variable="citation-number"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography second-field-align="flush" entry-spacing="0">
+    <sort>
+      <key macro="sortkey"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" suffix="."/>
+      <group delimiter=". " suffix=". ">
+        <text macro="author"/>
+        <text prefix="(" macro="year" suffix=")" />
+        <text macro="title"/>
+      </group>
+      <group suffix=".">
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text macro="book-publisher" suffix="."/>
+          </if>
+          <else-if type="paper-conference">
+            <group suffix="." delimiter=", ">
+              <text macro="conference"/>
+              <text variable="page"/>
+            </group>
+          </else-if>
+          <else-if type="chapter" match="any">
+            <group delimiter=" ">
+              <text term="in" text-case="capitalize-first"/>
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <text variable="container-title" font-style="italic"/>
+                  <text macro="edition" prefix="(" suffix=")"/>
+                </group>
+                <text macro="editor"/>
+              </group>
+            </group>
+            <group suffix="." delimiter=", " prefix=". ">
+              <text macro="book-publisher"/>
+              <text variable="page"/>
+            </group>
+          </else-if>
+          <else-if type="article-journal">
+            <group suffix="." delimiter=", ">
+              <text macro="journal"/>
+              <text variable="page"/>
+            </group>
+          </else-if>
+          <else>
+            <group suffix="." delimiter=", ">
+              <group delimiter=" " font-style="italic">
+                <text variable="container-title"/>
+                <text variable="volume"/>
+              </group>
+              <text variable="page"/>
+            </group>
+          </else>
+        </choose>
+      </group>
+      <text macro="access" prefix=" "/>
+      <text macro="pmcid" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>

--- a/mendeley/fogies-nih.csl
+++ b/mendeley/fogies-nih.csl
@@ -120,6 +120,13 @@
       </else>
     </choose>
   </macro>
+  <macro name="git">
+    <choose>
+      <if variable="GIT">
+        <text variable="GIT" prefix="GitHub: "/>
+      </if>
+    </choose>
+  </macro>
   <macro name="sortkey">
     <group delimiter=" ">
 	  <choose>
@@ -202,6 +209,7 @@
       </group>
       <text macro="access" prefix=" "/>
       <text macro="pmcid" prefix=" "/>
+      <text macro="git" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Adds a DOI and PMCID for the document. PMIDs will be used if PMCID is not provided.

To add PMCID in mendeley, go to "Notes" tab and add the id in the first two sentences of the notes section using the format:

{:PMCID: 0000000} -- replace the 0000000 with actual PMCID.

Any text entered in a new line / outside of the brackets will be ignored in the bibliography.